### PR TITLE
Fix Windows build

### DIFF
--- a/BasiliskII/src/Windows/Makefile.in
+++ b/BasiliskII/src/Windows/Makefile.in
@@ -118,7 +118,7 @@ $(APP): $(XPLATSRCS) $(OBJ_DIR) $(OBJS)
 	$(CXX) -o $@ $(LDFLAGS) $(OBJS) $(LIBS) $(SDL_LIBS)
 
 $(UI_APP): $(XPLATSRCS) $(OBJ_DIR) $(UI_OBJS)
-	$(CXX) -o $@ $(LDFLAGS) $(UI_OBJS) $(LIBS) $(GTK_LIBS) -mwindows -mno-cygwin
+	$(CXX) -o $@ $(LDFLAGS) $(UI_OBJS) $(LIBS) $(GTK_LIBS) -mwindows 
 
 mostlyclean:
 	rm -f $(APP) $(UI_APP) $(OBJ_DIR)/* core* *.core *~ *.bak
@@ -149,7 +149,7 @@ $(OBJ_DIR)/%.o : %.cpp
 $(OBJ_DIR)/%.o : %.s
 	$(CC) $(CPPFLAGS) $(DEFS) $(CFLAGS) -c $< -o $@
 $(OBJ_DIR)/prefs_editor_gtk.o: prefs_editor_gtk.cpp
-	$(CXX) -O2 -mno-cygwin -mms-bitfields $(CPPFLAGS) $(DEFS) $(GTK_CFLAGS) -c $< -o $@
+	$(CXX) -O2 -mms-bitfields $(CPPFLAGS) $(DEFS) $(GTK_CFLAGS) -c $< -o $@
 
 # Windows resources
 $(OBJ_DIR)/%.o: %.rc

--- a/BasiliskII/src/Windows/Makefile.in
+++ b/BasiliskII/src/Windows/Makefile.in
@@ -118,7 +118,7 @@ $(APP): $(XPLATSRCS) $(OBJ_DIR) $(OBJS)
 	$(CXX) -o $@ $(LDFLAGS) $(OBJS) $(LIBS) $(SDL_LIBS)
 
 $(UI_APP): $(XPLATSRCS) $(OBJ_DIR) $(UI_OBJS)
-	$(CXX) -o $@ $(LDFLAGS) $(UI_OBJS) $(LIBS) $(GTK_LIBS) -mwindows 
+	$(CXX) -o $@ $(LDFLAGS) $(UI_OBJS) $(LIBS) -Wl,-Bdynamic $(GTK_LIBS) -Wl,-Bstatic -mwindows -static-libgcc
 
 mostlyclean:
 	rm -f $(APP) $(UI_APP) $(OBJ_DIR)/* core* *.core *~ *.bak

--- a/BasiliskII/src/Windows/configure.ac
+++ b/BasiliskII/src/Windows/configure.ac
@@ -269,10 +269,13 @@ if [[ "x$HAVE_GCC30" = "xyes" ]]; then
   AC_CACHE_CHECK([whether the compiler supports -fno-strict-aliasing],
     ac_cv_gcc_no_strict_aliasing, [
     AC_TRY_COMPILE([],[],
-      [ac_cv_gcc_no_strict_aliasing=yes; AC_SUBST(SLIRP_CFLAGS, "-fno-strict-aliasing")],
+      [ac_cv_gcc_no_strict_aliasing=yes],
       [ac_cv_gcc_no_strict_aliasing=no])
   ])
   CFLAGS="$SAVED_CFLAGS"
+  if test "x$ac_cv_gcc_no_strict_aliasing" = xyes; then
+       AC_SUBST(SLIRP_CFLAGS, "-fno-strict-aliasing")
+  fi
 fi
 
 dnl Select appropriate CPU source and REGPARAM define.

--- a/BasiliskII/src/Windows/main_windows.cpp
+++ b/BasiliskII/src/Windows/main_windows.cpp
@@ -361,10 +361,10 @@ int main(int argc, char **argv)
 	D(bug("Mac ROM starts at %p (%08x)\n", ROMBaseHost, ROMBaseMac));
 	
 	// Get rom file path from preferences
-	auto rom_path = tstr(PrefsFindString("rom"));
+	const char * rom_path = PrefsFindString("rom");
 
 	// Load Mac ROM
-	HANDLE rom_fh = CreateFile(rom_path ? rom_path.get() : ROM_FILE_NAME,
+	HANDLE rom_fh = CreateFile(rom_path ? rom_path : ROM_FILE_NAME,
 							   GENERIC_READ,
 							   FILE_SHARE_READ, NULL,
 							   OPEN_EXISTING,

--- a/BasiliskII/src/Windows/posix_emu.h
+++ b/BasiliskII/src/Windows/posix_emu.h
@@ -125,6 +125,6 @@ struct my_utimbuf
 };
 
 // Your compiler may have different "struct stat" -> edit "struct my_stat"
-#define validate_stat_struct ( sizeof(struct my_stat) == sizeof(struct stat) )
+#define validate_stat_struct ( sizeof(struct my_stat) == sizeof(struct _stat) )
 
 #define st_crtime st_ctime

--- a/BasiliskII/src/Windows/prefs_editor_gtk.cpp
+++ b/BasiliskII/src/Windows/prefs_editor_gtk.cpp
@@ -910,10 +910,11 @@ static void create_jit_pane(GtkWidget *top)
 #endif
 
 	set_jit_sensitive();
-#endif
 
 #ifdef SHEEPSHAVER
 	make_checkbox(box, STR_JIT_68K_CTRL, "jit68k", GTK_SIGNAL_FUNC(tb_jit_68k));
+#endif
+
 #endif
 }
 

--- a/BasiliskII/src/Windows/sysdeps.h
+++ b/BasiliskII/src/Windows/sysdeps.h
@@ -21,10 +21,6 @@
 #ifndef SYSDEPS_H
 #define SYSDEPS_H
 
-#ifdef __MINGW32__
-#define _UNICODE
-#endif
-
 #if !defined _MSC_VER && !defined __STDC__
 #error "Your compiler is not ANSI. Get a real one."
 #endif

--- a/BasiliskII/src/slirp/slirp.h
+++ b/BasiliskII/src/slirp/slirp.h
@@ -33,6 +33,11 @@ typedef unsigned long ioctlsockopt_t;
 # include <WS2tcpip.h>
 
 #ifdef __MINGW32__
+/* Once upon a time MINGW32 didn't have inet_ntop() and inet_pton() in the headers?
+   In a new mingw32 WS2tcpip.h that has them, the Inet*A defines point to them. */
+
+#ifndef InetNtopA
+
 char * WSAAPI inet_ntop(
   INT     Family,
   PVOID  pAddr,
@@ -40,12 +45,19 @@ char * WSAAPI inet_ntop(
   size_t StringBufSize
 );
 
+#endif
+
+#ifndef InetPtonA
+
 INT WSAAPI inet_pton(
   INT     Family,
   const char * pszAddrString,
   PVOID  pAddrBuf
 );
+
 #endif
+
+#endif /* __MINGW32__ */
 
 # include <sys/timeb.h>
 # include <iphlpapi.h>

--- a/SheepShaver/Makefile
+++ b/SheepShaver/Makefile
@@ -99,7 +99,7 @@ links:
 	    case $$i in *codegen_x86.h) o=kpx_cpu/src/cpu/jit/x86/codegen_x86.h;; esac; \
 	    SUB=`echo $$o | sed 's;[^/]*/;../;g' | sed 's;[^/]*$$;;'` ;\
 	    cur_link=src/$$o ;\
-	    if [ -d "$$cur_link" ]; then rm -rf "$$cur_link"; fi ;\
+	    if [ -e "$$cur_link" ]; then rm -rf "$$cur_link"; fi ;\
 	    ln -sf "$$PREFIX$$SUB$(B2_TOPDIR)/src/$$i" $$cur_link; \
 	  fi; \
 	done;

--- a/SheepShaver/src/Windows/Makefile.in
+++ b/SheepShaver/src/Windows/Makefile.in
@@ -128,7 +128,7 @@ $(APP): $(XPLATSRCS) $(OBJ_DIR) $(OBJS)
 	$(CXX) -o $(APP) $(LDFLAGS) $(OBJS) $(LIBS) $(SDL_LIBS)
 
 $(UI_APP): $(XPLATSRCS) $(OBJ_DIR) $(UI_OBJS)
-	$(CXX) -o $@ $(LDFLAGS) $(UI_OBJS) $(LIBS) $(GTK_LIBS) -mwindows -mno-cygwin
+	$(CXX) -o $@ $(LDFLAGS) $(UI_OBJS) $(LIBS) -Wl,-Bdynamic $(GTK_LIBS) -Wl,-Bstatic -mwindows -static-libgcc
 
 mostlyclean:
 	rm -f $(APP) $(UI_APP) $(OBJ_DIR)/* core* *.core *~ *.bak
@@ -163,7 +163,7 @@ $(OBJ_DIR)/%.o : %.S
 	$(AS) $(ASFLAGS) -o $@ $*.out.s
 	rm $*.out.s
 $(OBJ_DIR)/prefs_editor_gtk.o: prefs_editor_gtk.cpp
-	$(CXX) -O2 -mno-cygwin -mms-bitfields $(CPPFLAGS) $(DEFS) $(GTK_CFLAGS) -c $< -o $@
+	$(CXX) -O2 -mms-bitfields $(CPPFLAGS) $(DEFS) $(GTK_CFLAGS) -c $< -o $@
 
 # Windows resources
 $(OBJ_DIR)/%.o: %.rc

--- a/SheepShaver/src/Windows/Makefile.in
+++ b/SheepShaver/src/Windows/Makefile.in
@@ -76,6 +76,7 @@ SRCS = ../main.cpp main_windows.cpp ../prefs.cpp ../prefs_items.cpp prefs_window
 
 UI_SRCS = ../prefs.cpp prefs_windows.cpp prefs_editor_gtk.cpp xpram_windows.cpp \
 	../prefs_items.cpp ../user_strings.cpp user_strings_windows.cpp util_windows.cpp \
+	../dummy/prefs_dummy.cpp \
 	b2ether/packet32.cpp SheepShaverGUI.rc
 
 UI_APP = SheepShaverGUI.exe

--- a/SheepShaver/src/Windows/configure.ac
+++ b/SheepShaver/src/Windows/configure.ac
@@ -186,10 +186,13 @@ if [[ "x$HAVE_GCC30" = "xyes" ]]; then
   AC_CACHE_CHECK([whether the compiler supports -fno-strict-aliasing],
     ac_cv_gcc_no_strict_aliasing, [
     AC_TRY_COMPILE([],[],
-      [ac_cv_gcc_no_strict_aliasing=yes; AC_SUBST(SLIRP_CFLAGS, "-fno-strict-aliasing")],
+      [ac_cv_gcc_no_strict_aliasing=yes],
       [ac_cv_gcc_no_strict_aliasing=no])
   ])
   CFLAGS="$SAVED_CFLAGS"
+  if test "x$ac_cv_gcc_no_strict_aliasing" = xyes; then
+       AC_SUBST(SLIRP_CFLAGS, "-fno-strict-aliasing")
+  fi
 fi
 
 dnl CPU emulator sources

--- a/SheepShaver/src/Windows/sysdeps.h
+++ b/SheepShaver/src/Windows/sysdeps.h
@@ -41,7 +41,9 @@
 #undef _TEXT
 #include <time.h>
 #ifdef __WIN32__
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <WinSock2.h>
 #endif
 #include <sys/types.h>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,29 +1,41 @@
+
+# Build worker image, see https://www.appveyor.com/docs/windows-images-software/
+image: Visual Studio 2019
+
 install:
-  - set PATH=C:\cygwin\bin;C:\cygwin64\bin;%PATH%
-  - '%CYG_ROOT%\setup-%CYG_ARCH%.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l %CYG_ROOT%/var/cache/setup -P autoconf -P automake -P bison -P libgmp-devel -P gcc-core -P gcc-g++ -P mingw-runtime -P mingw-binutils -P mingw-gcc-core -P mingw-gcc-g++ -P mingw-pthreads -P mingw-w32api -P libtool -P make -P gettext-devel -P gettext -P intltool -P libiconv -P pkg-config -P git -P wget -P curl -P libgtk2.0-devel -P libSDL2-devel'
+  # Update package index
+  - '%MSYS2_DIR%\usr\bin\env.exe %MSYS2_DIR%\usr\bin\bash --login -c ''/usr/bin/pacman -Sy --noconfirm'' '
+  # Install packages needed to build macemu
+  # After installing a package with pacman -S, check that it is actually installed with pacman -Qi 
+  # because pacman -S reports success even if the package install failed when some necessary package downloads timed out
+  - '%MSYS2_DIR%\usr\bin\env.exe %MSYS2_DIR%\usr\bin\bash --login -c ''/usr/bin/pacman -S --noconfirm mingw-w64-i686-gtk2'' '
+  - '%MSYS2_DIR%\usr\bin\env.exe %MSYS2_DIR%\usr\bin\bash --login -c ''/usr/bin/pacman -Qi mingw-w64-i686-gtk2'' '
+  - '%MSYS2_DIR%\usr\bin\env.exe %MSYS2_DIR%\usr\bin\bash --login -c ''/usr/bin/pacman -S --noconfirm mingw-w64-i686-SDL2'' '
+  - '%MSYS2_DIR%\usr\bin\env.exe %MSYS2_DIR%\usr\bin\bash --login -c ''/usr/bin/pacman -Qi mingw-w64-i686-SDL2'' '
 
 environment:
+  global:
+    MSYS2_DIR: C:\msys64
+    MSYS2_PLATFORM: MINGW32
   matrix:
-    - CYG_ARCH: x86_64
-      CYG_ROOT: C:/cygwin64
-      MACEMU_PROJECT: BasiliskII
-    - CYG_ARCH: x86_64
-      CYG_ROOT: C:/cygwin64
-      MACEMU_PROJECT: SheepShaver
+    - MACEMU_PROJECT: BasiliskII
+      CONFIGURE_OPTIONS: 
+    - MACEMU_PROJECT: SheepShaver
+      CONFIGURE_OPTIONS: 
 
+cache:
+  - $(MSYS2_DIR)\var\cache\pacman\pkg  # downloaded MSYS2 pacman packages
 
-build: off
-
-before_test:
+before_build:
   - gcc -v
   - g++ -v
 
-test_script:
-  # https://help.appveyor.com/discussions/problems/5170-progresspreference-not-works-always-shown-preparing-modules-for-first-use-in-stderr
-  - ps: $ProgressPreference = "SilentlyContinue"
-  - 'echo %MACEMU_PROJECT%'
-  - 'cd %MACEMU_PROJECT%'
-  - ps: ($env:MACEMU_PROJECT -eq "SheepShaver") -and $(make links)
-  - cd src/Windows
-  - sh ../Unix/autogen.sh
-  - make
+build_script:
+  - if %MACEMU_PROJECT%==SheepShaver %MSYS2_DIR%\usr\bin\env.exe MSYSTEM=%MSYS2_PLATFORM% %MSYS2_DIR%\usr\bin\bash.exe --login -c 'cd /c/projects/macemu/%MACEMU_PROJECT%; make links'
+  - '%MSYS2_DIR%\usr\bin\env.exe MSYSTEM=%MSYS2_PLATFORM% %MSYS2_DIR%\usr\bin\bash.exe --login -c ''cd /c/projects/macemu/%MACEMU_PROJECT%/src/Windows; ../Unix/autogen.sh %CONFIGURE_OPTIONS%'' '
+  - '%MSYS2_DIR%\usr\bin\env.exe MSYSTEM=%MSYS2_PLATFORM% %MSYS2_DIR%\usr\bin\bash.exe --login -c ''cd /c/projects/macemu/%MACEMU_PROJECT%/src/Windows; make -j2'' '
+
+artifacts:
+  - path: $(MACEMU_PROJECT)\src\Windows\config.log
+  - path: $(MACEMU_PROJECT)\src\Windows\$(MACEMU_PROJECT).exe
+  - path: $(MACEMU_PROJECT)\src\Windows\$(MACEMU_PROJECT)GUI.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,8 +27,8 @@ cache:
   - $(MSYS2_DIR)\var\cache\pacman\pkg  # downloaded MSYS2 pacman packages
 
 before_build:
-  - gcc -v
-  - g++ -v
+  - '%MSYS2_DIR%\usr\bin\env.exe MSYSTEM=%MSYS2_PLATFORM% %MSYS2_DIR%\usr\bin\bash.exe --login -c ''gcc -v'' '
+  - '%MSYS2_DIR%\usr\bin\env.exe MSYSTEM=%MSYS2_PLATFORM% %MSYS2_DIR%\usr\bin\bash.exe --login -c ''g++ -v'' '
 
 build_script:
   - if %MACEMU_PROJECT%==SheepShaver %MSYS2_DIR%\usr\bin\env.exe MSYSTEM=%MSYS2_PLATFORM% %MSYS2_DIR%\usr\bin\bash.exe --login -c 'cd /c/projects/macemu/%MACEMU_PROJECT%; make links'


### PR DESCRIPTION
This is a set of changes to get the emaculation codebase building in MSYS2. It is mostly changes cherry picked from out of kanjitalk755's master. 

This is a sort of minimal set. Building is not to say working, this is a starting point for you.

If you have some other way of building that supports e.g. your `-mno-cygwin` etc. that you want to stay compatible with you'll need to rework this to maintain compatibility.

This PR includes the contents of #136.