### PR TITLE
Fix Basilisk II crash on Linux aarch64

### DIFF
--- a/BasiliskII/src/CrossPlatform/vm_alloc.cpp
+++ b/BasiliskII/src/CrossPlatform/vm_alloc.cpp
@@ -270,10 +270,11 @@ void * vm_acquire(size_t size, int options)
 		return VM_MAP_FAILED;
 	
 #if DIRECT_ADDRESSING
-	// Sanity check to prevent crash on 64-bit when direct addressing
-	// FIXME: this results in a misleading "out of memory" error to the user when it fails
-	if (sizeof(void *) == 8 && (options & VM_MAP_32BIT) && !((char *)addr <= (char *)0xffffffff))
-		return VM_MAP_FAILED;
+	// If VM_MAP_32BIT and MAP_BASE fail to ensure
+	// a 32-bit address crash now instead of later.
+	// FIXME: make everything 64-bit clean and tear this all out.
+	if(sizeof(void *) > 4 && (options & VM_MAP_32BIT))
+		assert((size_t)addr<0xffffffffL);
 #endif
 
 	next_address = (char *)addr + size;

--- a/BasiliskII/src/CrossPlatform/vm_alloc.cpp
+++ b/BasiliskII/src/CrossPlatform/vm_alloc.cpp
@@ -95,18 +95,17 @@ typedef unsigned long vm_uintptr_t;
    don't get addresses above when the program is run on AMD64.
    NOTE: this is empirically determined on Linux/x86.  */
 #define MAP_BASE	0x10000000
-#elif !REAL_ADDRESSING
+#elif DIRECT_ADDRESSING
 /* linux does not implement any useful fallback behavior
    such as allocating the next available address
    and the first 4k-64k of address space is marked unavailable
    for security reasons (see https://wiki.debian.org/mmap_min_addr)
    so we must start requesting after the first page
-   (or we get a high 64bit address and break on aarch64)
+   or we get a high 64bit address that will crash direct addressing
 
-   leaving NULL unmapped is a good idea anyway for debugging reasons
-   so we do this unconditionally on all platforms */
+   leaving NULL unmapped is a good idea anyway for debugging reasons */
 #define MAP_BASE	0x00010000
-#else /* must be 0x0 when REAL_ADDRESSING=1 */
+#else
 #define MAP_BASE	0x00000000
 #endif
 static char * next_address = (char *)MAP_BASE;
@@ -270,9 +269,12 @@ void * vm_acquire(size_t size, int options)
 	if ((addr = mmap((caddr_t)next_address, size, VM_PAGE_DEFAULT, the_map_flags, fd, 0)) == (void *)MAP_FAILED)
 		return VM_MAP_FAILED;
 	
-	// Sanity checks for 64-bit platforms
+#if DIRECT_ADDRESSING
+	// Sanity check to prevent crash on 64-bit when direct addressing
+	// FIXME: this results in a misleading "out of memory" error to the user when it fails
 	if (sizeof(void *) == 8 && (options & VM_MAP_32BIT) && !((char *)addr <= (char *)0xffffffff))
 		return VM_MAP_FAILED;
+#endif
 
 	next_address = (char *)addr + size;
 #elif defined(HAVE_WIN32_VM)

--- a/BasiliskII/src/CrossPlatform/vm_alloc.h
+++ b/BasiliskII/src/CrossPlatform/vm_alloc.h
@@ -36,6 +36,8 @@ extern "C" {
 }
 #endif
 
+#include <cassert>
+
 /* Return value of `vm_acquire' in case of an error.  */
 #ifdef HAVE_MACH_VM
 #define VM_MAP_FAILED			((void *)-1)


### PR DESCRIPTION
I just had an... interesting exchange with upstream then discovered the action is over here. But it did improve my understanding of the various addressing modes. So I offer my patch here. :)

Basilisk II fails to start a VM on Debian aarch64, in my case a Raspi4.

Add a printf debug and you can see this is because MAP_BASE defaults to 0x0 which is unavailable for security reasons on recent Linux distributions thus the memory allocator falls back on a standard allocation way up in 64bit address space, which fails the "sanity check" and returns a misleading "not enough memory" error to the user.

```
--- a/BasiliskII/src/CrossPlatform/vm_alloc.cpp
+++ b/BasiliskII/src/CrossPlatform/vm_alloc.cpp
@@ -270,6 +270,7 @@ void * vm_acquire(size_t size, int options)
 
        if ((addr = mmap((caddr_t)next_address, size, VM_PAGE_DEFAULT, the_map_flags, fd, 0)) == (void *)MAP_FAILED)
                return VM_MAP_FAILED;
+       printf("mmap next=%p got=%p\n",next_address,addr);
        
        // Sanity checks for 64-bit platforms
        if (sizeof(void *) == 8 && (options & VM_MAP_32BIT) && !((char *)addr <= (char *)0xffffffff))
```
```
$ ./build/BasiliskII 
Basilisk II V1.1 by Christian Bauer et al.
mmap next=(nil) got=0x7f9df00000
ERROR: Not enough free memory.
```

There are two fixes for this. Direct addressing mode can be fixed by bumping MAP_BASE up past the security/debug guard. Direct addressing mode is what configure currently defaults to on aarch64.

The other fix is to use banked addressing mode instead. This still requires a fix to not perform the "sanity check" which is not needed in this case.

This patch fixes both addressing modes. The default remains on direct addressing mode.

I have not touched the linux i386|FreeBSD|HAVE_LINKER_SCRIPT case as I assume its working properly but the more I learn the codebase, the more inclined i am to revise that bit as well... :)

This should fix Basilisk II on aarch64 without breaking current cases. I've also tested Linux x86_64. Please test and tell me if it breaks anything. (windows and macOS have their own code paths and should be unaffected)

I have not gotten around to getting SheepShaver running yet so I have not tested it.