### PR TITLE
Change SheepShaver default build to direct addressing.

### DIFF
--- a/SheepShaver/src/Unix/configure.ac
+++ b/SheepShaver/src/Unix/configure.ac
@@ -57,13 +57,13 @@ AC_ARG_WITH(libvhd,
 
 dnl Addressing mode
 AC_ARG_ENABLE(addressing,
-  [  --enable-addressing=AM  set the addressing mode to use [default=real]],
+  [  --enable-addressing=AM  set the addressing mode to use [default=direct]],
   [case "$enableval" in
    real)        WANT_ADDRESSING_MODE="real";;
    direct)      WANT_ADDRESSING_MODE="direct";;
    direct,0x*)  WANT_ADDRESSING_MODE="direct"; NATMEM_OFFSET=`echo "$enableval" | sed -n '/direct,\(0[[xX]][[0-9A-Fa-f]]*\([[UuLl]]\{1,2\}\)\?\)$/s//\1/p'`;;
    esac],
-  [WANT_ADDRESSING_MODE="real"]
+  [WANT_ADDRESSING_MODE="direct"]
 )
 
 dnl SDL options.

--- a/SheepShaver/src/Unix/configure.ac
+++ b/SheepShaver/src/Unix/configure.ac
@@ -29,7 +29,7 @@ case $target_os in
 esac
 
 dnl Options.
-AC_ARG_ENABLE(jit,          [  --enable-jit            enable JIT compiler [default=yes]], [WANT_JIT=$enableval], [WANT_JIT=yes])
+AC_ARG_ENABLE(jit,          [  --enable-jit            enable JIT compiler [default=no]], [WANT_JIT=$enableval], [WANT_JIT=no])
 AC_ARG_ENABLE(ppc-emulator, [  --enable-ppc-emulator   use the selected PowerPC emulator [default=auto]], [WANT_EMULATED_PPC=$enableval], [WANT_EMULATED_PPC=auto])
 AC_ARG_ENABLE(fbdev-dga,    [  --enable-fbdev-dga      use direct frame buffer access via /dev/fb0 [default=yes]], [WANT_FBDEV_DGA=$enableval], [WANT_FBDEV_DGA=yes])
 AC_ARG_ENABLE(xf86-dga,     [  --enable-xf86-dga       use the XFree86 DGA extension [default=yes]], [WANT_XF86_DGA=$enableval], [WANT_XF86_DGA=yes])


### PR DESCRIPTION
Modern security standards mean real addressing is not possible on Linux/FreeBSD systems going forward. Instead of disabling security measures, simply use direct addressing instead.

If you are attached to real addressing for some reason, you are free to override the default build. :)

fixes #135