### PR TITLE
Add x86_64 32-bit address mode prefix to ix86_skip_instruction

### DIFF
--- a/BasiliskII/src/CrossPlatform/sigsegv.cpp
+++ b/BasiliskII/src/CrossPlatform/sigsegv.cpp
@@ -1018,6 +1018,15 @@ static bool ix86_skip_instruction(SIGSEGV_REGISTER_TYPE * regs)
 		transfer_size = SIZE_WORD;
 	}
 
+#if defined(__x86_64__) || defined(_M_X64)
+	// Address size override
+	if (*eip == 0x67) {
+		// 32-bit address
+		eip++;
+		len++;
+	}
+#endif
+
 	// REX prefix
 #if defined(__x86_64__) || defined(_M_X64)
 	struct rex_t {

--- a/SheepShaver/src/CrossPlatform/sigsegv.cpp
+++ b/SheepShaver/src/CrossPlatform/sigsegv.cpp
@@ -1018,6 +1018,16 @@ static bool ix86_skip_instruction(SIGSEGV_REGISTER_TYPE * regs)
 		transfer_size = SIZE_WORD;
 	}
 
+#if defined(__x86_64__) || defined(_M_X64)
+	bool x86_64_address_32 = false;
+	if (*eip == 0x67) {
+		eip++;
+		len++;
+		x86_64_address_32 = true;
+	}
+	// FIXME do something with this
+#endif
+
 	// REX prefix
 #if defined(__x86_64__) || defined(_M_X64)
 	struct rex_t {

--- a/SheepShaver/src/CrossPlatform/sigsegv.cpp
+++ b/SheepShaver/src/CrossPlatform/sigsegv.cpp
@@ -1019,6 +1019,7 @@ static bool ix86_skip_instruction(SIGSEGV_REGISTER_TYPE * regs)
 	}
 
 #if defined(__x86_64__) || defined(_M_X64)
+	// Address size override
 	bool x86_64_address_32 = false;
 	if (*eip == 0x67) {
 		eip++;

--- a/SheepShaver/src/CrossPlatform/sigsegv.cpp
+++ b/SheepShaver/src/CrossPlatform/sigsegv.cpp
@@ -1020,13 +1020,11 @@ static bool ix86_skip_instruction(SIGSEGV_REGISTER_TYPE * regs)
 
 #if defined(__x86_64__) || defined(_M_X64)
 	// Address size override
-	bool x86_64_address_32 = false;
 	if (*eip == 0x67) {
+		// 32-bit address
 		eip++;
 		len++;
-		x86_64_address_32 = true;
 	}
-	// FIXME do something with this
 #endif
 
 	// REX prefix


### PR DESCRIPTION
In the sigsegv instruction skipping for x86_64, skip the `0x67` 32-bit address mode "legacy prefix" (see https://wiki.osdev.org/X86-64_Instruction_Encoding#Legacy_Prefixes)

Fixes #143 